### PR TITLE
Listener thread does not sleep

### DIFF
--- a/include/nadjieb/mjpeg_streamer.hpp
+++ b/include/nadjieb/mjpeg_streamer.hpp
@@ -265,14 +265,14 @@ class MJPEGStreamer
             fd_set fd;
             FD_ZERO(&fd);
 
-            struct timeval to;
-            to.tv_sec = 1;
-            to.tv_usec = 0;
-
             auto master_socket = this->master_socket_;
 
             while (this->isAlive())
             {
+                struct timeval to;
+                to.tv_sec = 1;
+                to.tv_usec = 0;
+
                 FD_SET(this->master_socket_, &fd);
 
                 if (select(this->master_socket_ + 1, &fd, nullptr, nullptr, &to) > 0)

--- a/single_include/nadjieb/mjpeg_streamer.hpp
+++ b/single_include/nadjieb/mjpeg_streamer.hpp
@@ -359,14 +359,14 @@ class MJPEGStreamer
             fd_set fd;
             FD_ZERO(&fd);
 
-            struct timeval to;
-            to.tv_sec = 1;
-            to.tv_usec = 0;
-
             auto master_socket = this->master_socket_;
 
             while (this->isAlive())
             {
+                struct timeval to;
+                to.tv_sec = 1;
+                to.tv_usec = 0;
+
                 FD_SET(this->master_socket_, &fd);
 
                 if (select(this->master_socket_ + 1, &fd, nullptr, nullptr, &to) > 0)


### PR DESCRIPTION
`select` with timeout overwrites the value stored in `to`.
It needs to be initialized explicitly every time before calling `select`.