### PR TITLE
Bump CMake minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 
 ##
 ## PROJECT
@@ -65,11 +65,7 @@ endif()
 ##
 add_library(${NADJIEB_MJPEG_STREAMER_TARGET_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${NADJIEB_MJPEG_STREAMER_TARGET_NAME} ALIAS ${NADJIEB_MJPEG_STREAMER_TARGET_NAME})
-if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
-    target_compile_features(${NADJIEB_MJPEG_STREAMER_TARGET_NAME} INTERFACE cxx_range_for)
-else()
-    target_compile_features(${NADJIEB_MJPEG_STREAMER_TARGET_NAME} INTERFACE cxx_std_17)
-endif()
+target_compile_features(${NADJIEB_MJPEG_STREAMER_TARGET_NAME} INTERFACE cxx_std_17)
 
 target_include_directories(
     ${NADJIEB_MJPEG_STREAMER_TARGET_NAME}


### PR DESCRIPTION
Nothing special, I updated the CMake required version to 3.10 because since 3.31 CMake issues this warning that cannot be suppressed:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
   Compatibility with CMake < 3.10 will be removed from a future version of
   CMake.
 
   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
   to tell CMake that the project requires at least <min> but has been updated
   to work with policies introduced by <max> or earlier.
```

See [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) documentation.